### PR TITLE
Fix some typos and mistakes and fix step 6 (1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Now, you should type `npm install discord.js`, we are installing the discord.js 
 ### Step five, getting the files
 Download `bot.js` and `config.json`
 
-### Step six (I)
+### Step six (I), getting your bot's token
 Get your bots token. Reminder, bot tokens are key information that gives complete access to your bot.
 ![Step six I](https://i.imgur.com/ytSLIi2.png "Step Six I")
 

--- a/bot.js
+++ b/bot.js
@@ -34,7 +34,7 @@ bot.on("message", message => {
 
     if (command === "kick") {
         if (!message.member.hasPermission('KICK_MEMBERS'))
-            return message.channel.send("Insufficient permissionss (Requires `KICK_MEMBERS`)")
+            return message.channel.send("Insufficient permissions (Requires permission `Kick members`)")
         const member = message.mentions.members.first();
         if (!member)
             return message.channel.send("You have not mentioned a user")
@@ -54,7 +54,7 @@ bot.on("message", message => {
 
     if (command === "ban") {
         if (!message.member.hasPermission('BAN_MEMBERS'))
-            return message.channel.send("Insufficient permissionss (Requires `BAN_MEMBERS`)")
+            return message.channel.send("Insufficient permissions (Requires permission `Ban members`)")
         const member = message.mentions.members.first();
         if (!member)
             return message.channel.send("You have not mentioned a user")
@@ -74,7 +74,7 @@ bot.on("message", message => {
 
     if (command === "add") {
         if (!message.member.hasPermission('MANAGE_ROLES'))
-            return message.channel.send("Insufficient permissionss (Requires `MANAGE_ROLES`)")
+            return message.channel.send("Insufficient permissions (Requires permission `Manage roles`)")
         const member = message.mentions.members.first()
         if (!member)
             return message.channel.send("You have not mentioned a user")
@@ -93,7 +93,7 @@ bot.on("message", message => {
 
     if (command === "remove") {
         if (!message.member.hasPermission('MANAGE_ROLES'))
-            return message.channel.send("Insufficient permissionss (Requires `MANAGE_ROLES`)")
+            return message.channel.send("Insufficient permissions (Requires permission `Manage roles`)")
         const member = message.mentions.members.first()
         if (!member)
             return message.channel.send("You have not mentioned a user")


### PR DESCRIPTION
Fixed spelling mistakes in "permissions" and changed BAN_MEMBERS, KICK_MEMBERS, and MANAGE_ROLES, to the permissions, as it is displayed without underscore in discord. The typos came when you migrated the code to discord.js v 12.  Updated README.md.
Reviews are welcome. 